### PR TITLE
Expose intro animation timeline ref

### DIFF
--- a/momentie-blog/src/app/page.tsx
+++ b/momentie-blog/src/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { MomentieLogo } from "@/components/MomentieLogo";
 import { WelcomeMessage } from "@/components/WelcomeMessage";
 import { YumiSignature } from "@/components/YumiSignature";
@@ -12,12 +12,17 @@ export default function Home() {
   const yumiRef = useRef<HTMLDivElement>(null);
 
   // Use the custom animation hook
-  useIntroAnimation({
+  const { timelineRef } = useIntroAnimation({
     containerRef,
     svgRef,
     welcomeRef,
     yumiRef,
   });
+
+  // Example external control
+  useEffect(() => {
+    timelineRef.current?.play();
+  }, [timelineRef]);
 
   return (
     <main className="bg-[--color-momentie-bg] min-h-screen flex flex-col items-center justify-center px-4">

--- a/momentie-blog/src/hooks/useIntroAnimation.ts
+++ b/momentie-blog/src/hooks/useIntroAnimation.ts
@@ -234,6 +234,6 @@ export function useIntroAnimation({
 
   return {
     isClient,
-    timeline: timelineRef.current,
+    timelineRef,
   };
 }


### PR DESCRIPTION
## Summary
- Return GSAP timeline ref from intro animation hook
- Update Home page to use returned timeline ref and allow external control

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afd1433e488323b3b7e641cae2d0d9