### PR TITLE
chore: enable full type checking

### DIFF
--- a/momentie-blog/src/hooks/useIntroAnimation.ts
+++ b/momentie-blog/src/hooks/useIntroAnimation.ts
@@ -4,10 +4,10 @@ import gsap from "gsap";
 import { type RefObject, useEffect, useRef, useState } from "react";
 
 interface UseIntroAnimationProps {
-  containerRef: RefObject<HTMLDivElement>;
-  svgRef: RefObject<SVGSVGElement>;
-  welcomeRef: RefObject<HTMLDivElement>;
-  yumiRef: RefObject<HTMLDivElement>;
+  containerRef: RefObject<HTMLDivElement | null>;
+  svgRef: RefObject<SVGSVGElement | null>;
+  welcomeRef: RefObject<HTMLDivElement | null>;
+  yumiRef: RefObject<HTMLDivElement | null>;
 }
 
 export function useIntroAnimation({

--- a/momentie-blog/tsconfig.json
+++ b/momentie-blog/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
+    "allowJs": false,
+    "skipLibCheck": false,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- disable JS file inclusion and library type skipping to tighten TypeScript checks
- allow nullable refs in animation hook to satisfy strict ref typing

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_68afd14618a48323b192d710aaaf5052