### PR TITLE
fix: clean up intro animation on unmount

### DIFF
--- a/momentie-blog/src/hooks/useIntroAnimation.ts
+++ b/momentie-blog/src/hooks/useIntroAnimation.ts
@@ -27,7 +27,7 @@ export function useIntroAnimation({
   }, []);
 
   useGSAP(
-    () => {
+    (ctx) => {
       // Only run animations on client side after hydration
       if (!isClient) return;
 
@@ -240,6 +240,10 @@ export function useIntroAnimation({
       }
 
       timelineRef.current = masterTimeline;
+      return () => {
+        ctx.revert();
+        timelineRef.current = null;
+      };
     },
     { scope: containerRef, dependencies: [isClient] },
   );


### PR DESCRIPTION
## Summary
- use `ctx` in `useGSAP` to control intro animation lifecycle
- revert GSAP context and clear timeline ref on component unmount

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68b091a80c308323a9a6b88b96526eaa