### PR TITLE
feat: forward extra props on YumiIllustration

### DIFF
--- a/momentie-blog/src/components/YumiIllustration.tsx
+++ b/momentie-blog/src/components/YumiIllustration.tsx
@@ -5,9 +5,9 @@ import { forwardRef } from "react";
 export const YumiIllustration = forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className = "" }, ref) => {
+>(({ className = "", ...props }, ref) => {
   return (
-    <div ref={ref} className={`${className}`}>
+    <div ref={ref} className={className} {...props}>
       <Image
         src="/Yumi_web_3.png"
         alt="Yumi Illustration"


### PR DESCRIPTION
## Summary
- allow YumiIllustration to accept and forward extra HTML attributes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google fonts)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68b091c2cc48832390c61799839ae79f