### PR TITLE
Use font variable for WelcomeMessage

### DIFF
--- a/momentie-blog/src/components/WelcomeMessage.tsx
+++ b/momentie-blog/src/components/WelcomeMessage.tsx
@@ -14,7 +14,7 @@ export const WelcomeMessage = forwardRef<HTMLDivElement, WelcomeMessageProps>(
         <div
           className="flex flex-col h-[140px] justify-center leading-[0] relative shrink-0 text-center w-full"
           style={{
-            fontFamily: "'IBM Plex Mono', monospace",
+            fontFamily: "var(--font-ibm-plex-mono, monospace)",
             fontStyle: "italic",
             fontSize: "48px",
             fontWeight: 400,


### PR DESCRIPTION
## Summary
- replace hard-coded IBM Plex Mono font with CSS variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist Mono` ...)*

------
https://chatgpt.com/codex/tasks/task_b_68b096a5279c832398f3fe2163a20aad